### PR TITLE
Add pyinstaller binaries support

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -12,7 +12,7 @@ steps:
   - pip install -r requirements.txt
   - make test-ci COMMIT_SHA=${DRONE_COMMIT_SHA}
 
-- name: make release binaries
+- name: release's binaries tests
   image: python:3-slim
   commands:
   - apt-get update && apt-get install -y make git binutils

--- a/.drone.yml
+++ b/.drone.yml
@@ -19,18 +19,19 @@ steps:
   - pip install -r requirements.txt
   - make build_and_test_release_binaries
 
-#- name: release
-#  image: python:3-slim
-#  environment:
-#    GITHUB_TOKEN:
-#      from_secret: GHR_TOKEN
-#  commands:
-#  - apt-get update && apt-get install -y make git curl ca-certificates
-#  - curl -L https://github.com/tcnksm/ghr/releases/download/v0.12.2/ghr_v0.12.2_linux_amd64.tar.gz -o /tmp/ghr.tar.gz
-#  - tar -xzvf /tmp/ghr.tar.gz -C /tmp --strip-components=1
-#  - mv /tmp/ghr /usr/local/bin/
-#  - chmod +x /usr/local/bin/ghr
-#  - pip install -r requirements.txt
-#  - make release GITHUB_TOKEN=$${GITHUB_TOKEN}
-#  when:
-#    branch: master
+- name: release
+  image: python:3-slim
+  environment:
+    GITHUB_TOKEN:
+      from_secret: GHR_TOKEN
+  commands:
+  - apt-get update && apt-get install -y make git curl ca-certificates binutils
+  - curl -L https://github.com/tcnksm/ghr/releases/download/v0.12.2/ghr_v0.12.2_linux_amd64.tar.gz -o /tmp/ghr.tar.gz
+  - tar -xzvf /tmp/ghr.tar.gz -C /tmp --strip-components=1
+  - mv /tmp/ghr /usr/local/bin/
+  - chmod +x /usr/local/bin/ghr
+  - pip install -r requirements.txt
+  - make release GITHUB_TOKEN=$${GITHUB_TOKEN}
+  when:
+    branch: improvement/add-pyinstaller-binaries-support
+

--- a/.drone.yml
+++ b/.drone.yml
@@ -33,5 +33,4 @@ steps:
   - pip install -r requirements.txt
   - make release GITHUB_TOKEN=$${GITHUB_TOKEN}
   when:
-    branch: improvement/add-pyinstaller-binaries-support
-
+    branch: master

--- a/.drone.yml
+++ b/.drone.yml
@@ -15,7 +15,7 @@ steps:
 - name: make release binaries
   image: python:3-slim
   commands:
-  - apt-get update && apt-get install -y make git
+  - apt-get update && apt-get install -y make git binutils
   - pip install -r requirements.txt
   - make build_and_test_release_binaries
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -12,3 +12,25 @@ steps:
   - pip install -r requirements.txt
   - make test-ci COMMIT_SHA=${DRONE_COMMIT_SHA}
 
+- name: make release binaries
+  image: python:3-slim
+  commands:
+  - apt-get update && apt-get install -y make git
+  - pip install -r requirements.txt
+  - make build_release_binaries
+
+#- name: release
+#  image: python:3-slim
+#  environment:
+#    GITHUB_TOKEN:
+#      from_secret: GHR_TOKEN
+#  commands:
+#  - apt-get update && apt-get install -y make git curl ca-certificates
+#  - curl -L https://github.com/tcnksm/ghr/releases/download/v0.12.2/ghr_v0.12.2_linux_amd64.tar.gz -o /tmp/ghr.tar.gz
+#  - tar -xzvf /tmp/ghr.tar.gz -C /tmp --strip-components=1
+#  - mv /tmp/ghr /usr/local/bin/
+#  - chmod +x /usr/local/bin/ghr
+#  - pip install -r requirements.txt
+#  - make release GITHUB_TOKEN=$${GITHUB_TOKEN}
+#  when:
+#    branch: master

--- a/.drone.yml
+++ b/.drone.yml
@@ -17,7 +17,7 @@ steps:
   commands:
   - apt-get update && apt-get install -y make git
   - pip install -r requirements.txt
-  - make build_release_binaries
+  - make build_and_test_release_binaries
 
 #- name: release
 #  image: python:3-slim

--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,12 @@ test:
 test-ci: test
     codecov --token=$${CODECOV_TOKEN} --commit=${COMMIT_SHA}
 
+release:
+    @echo "Not Implemented Yet."
+    exit 1
+
+build_and_test_release_binaries:
+    pyinstaller -F step_timer.py
+    pyinstaller -F send_to_prometheus_gateway
+    dist/step_timer --help
+    dist/send_to_prometheus_gateway --help

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,10 @@ test:
 test-ci: test
     codecov --token=$${CODECOV_TOKEN} --commit=${COMMIT_SHA}
 
-release:
-    @echo "Not Implemented Yet."
-    exit 1
+release: clear build_and_test_release_binaries
+    cd src
+    ghr -replace v1.0.0 dist/
+
 
 .ONESHELL: build_and_test_release_binaries
 build_and_test_release_binaries:
@@ -21,3 +22,7 @@ build_and_test_release_binaries:
     pyinstaller -F send_to_prometheus_gateway.py
     dist/step_timer --help
     dist/send_to_prometheus_gateway --help
+
+clear:
+    cd src
+    rm -rf dist/ rm -rf build/

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,10 @@ release:
     @echo "Not Implemented Yet."
     exit 1
 
+.ONESHELL: build_and_test_release_binaries
 build_and_test_release_binaries:
+    cd src
     pyinstaller -F step_timer.py
-    pyinstaller -F send_to_prometheus_gateway
+    pyinstaller -F send_to_prometheus_gateway.py
     dist/step_timer --help
     dist/send_to_prometheus_gateway --help

--- a/README.MD
+++ b/README.MD
@@ -39,7 +39,7 @@ You can send it to a prometheus gateway using the following commands:
 
 ```bash
     export PROMETHEUS_GATEWAY_ADDR=http://localhost:9091
-    ./send_to_prometheus_gateway --resource 'current_step.timer'
+    ./send_to_prometheus_gateway.py --resource 'current_step.timer'
 ```
 
 Supported args:
@@ -47,3 +47,6 @@ Supported args:
  * job: Name of the job that will be used on prometheus_gateway (`Default` by default :D)
  * prometheus_gateway_addr: URL address of the prometheus gateway (if not passed the env var `PROMETHEUS_GATEWAY_ADDR` will be used instead).
  
+ ### Binary Releases
+ 
+ You can find some binary releases created with `pyinstaller` that can be used by any linux with glibc support (`alpine` is not supported yet because it needs a muslibc build)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ click==7.0
 python-slugify[unidecode]==2.0.1
 pytest==5.0.1
 codecov==2.0.15
+PyInstaller==3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 prometheus-client==0.7.1
 click==7.0
-python-slugify==3.0.3
+python-slugify[unidecode]==2.0.1
 pytest==5.0.1
 codecov==2.0.15


### PR DESCRIPTION
From now on, its possible to download packaged binaries for linux-amd-64 arch, making it simple to use with CI steps.