### PR TITLE
Add StatsD Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ build_and_test_release_binaries:
     pyinstaller -F send_to_statsd.py
     dist/step_timer --help
     dist/send_to_prometheus_gateway --help
-    dist/send_to_statsd.py --help
+    dist/send_to_statsd --help
 
 clear:
     cd src

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ test-ci: test
 
 release: clear build_and_test_release_binaries
     cd src
-    ghr -replace v1.0.0 dist/
+    ghr -replace v1.1.0 dist/
 
 
 .ONESHELL: build_and_test_release_binaries
@@ -20,8 +20,10 @@ build_and_test_release_binaries:
     cd src
     pyinstaller -F step_timer.py
     pyinstaller -F send_to_prometheus_gateway.py
+    pyinstaller -F send_to_statsd.py
     dist/step_timer --help
     dist/send_to_prometheus_gateway --help
+    dist/send_to_statsd.py --help
 
 clear:
     cd src

--- a/README.MD
+++ b/README.MD
@@ -32,7 +32,15 @@ Supported args:
  * moment: Start, End or Summary
  * step_name: The name of the step that will be timed.
  * resource: The name of resource file that will be created (`current_step.timer` by default)
- 
+
+## Send to StatsD (or StatsD Exporter)
+
+You can send it to a statsd host using the following commands:
+```bash
+   export STATSD_HOST=localhost
+   ./send_to_statsd --resource 'current_step.timer' --metric "my.own.metric"
+```
+
 ## Send to Prometheus Gateway
 
 You can send it to a prometheus gateway using the following commands:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-slugify[unidecode]==2.0.1
 pytest==5.0.1
 codecov==2.0.15
 PyInstaller==3.5
+statsd==3.3.0

--- a/src/send_to_statsd.py
+++ b/src/send_to_statsd.py
@@ -1,0 +1,73 @@
+# coding: utf-8
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import argparse
+import os
+import sys
+
+import statsd
+
+sys.path.insert(0, '../')
+
+from src.shared import get_timed_step
+
+STATSD_HOST = os.getenv('STATSD_HOST', None)
+
+
+class StatsDGateway(object):
+    def __init__(self, host, port=8125, prefix=''):
+        self.host = host
+        self.port = port
+        self.prefix = prefix
+
+        self.client = statsd.StatsClient(self.host, self.port, self.prefix)
+
+    def send_gauge(self, metric, value):
+        self.client.gauge(metric, value)
+
+    def send_timer(self, metric, value):
+        raise NotImplementedError
+
+    def send_incr(self, metric, value):
+        raise NotImplementedError
+
+
+def send_timed_step_elapsed_time_in_seconds_to_statsd(resource,
+                                                      gateway,
+                                                      statsd_metric_name
+                                                      ):
+    # type: (str, StatsDGateway, str) -> (str, int)
+    timed_step = get_timed_step(resource)
+    gateway.send_gauge(statsd_metric_name, timed_step.elapsed_time_in_seconds)
+
+    return statsd_metric_name, timed_step.elapsed_time_in_seconds
+
+
+def get_cli_parser():
+    parser = argparse.ArgumentParser(description='Process some integers.')
+    parser.add_argument('--resource', type=str, required=True)
+    parser.add_argument('--host', type=str, required=False, default=STATSD_HOST)
+    parser.add_argument('--port', type=int, required=False, default=8125)
+    parser.add_argument('--metric', type=str,required=True)
+    parser.add_argument('--prefix', type=str, required=False, default='default')
+
+    return parser
+
+
+def parse_cli_args(parser):
+    args = parser.parse_args()
+    if not args.host:
+        raise Exception("You must provide an value for --host or set STATSD_HOST to the statsd host address.")
+
+    return args
+
+
+if __name__ == '__main__':
+    cli_parser = get_cli_parser()
+
+    args = parse_cli_args(cli_parser)
+
+    gateway = StatsDGateway(host=args.host, port=args.port, prefix=args.prefix)
+    send_timed_step_elapsed_time_in_seconds_to_statsd(args.resource, gateway, args.metric)

--- a/src/shared.py
+++ b/src/shared.py
@@ -1,0 +1,11 @@
+# coding: utf-8
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from src.step_timer import retrieve_time_step_object_from_pickled_file, TimedStep
+
+
+def get_timed_step(resource):
+    # type: (str) -> TimedStep
+    return retrieve_time_step_object_from_pickled_file(resource)

--- a/src/tests/test_send_to_statsd.py
+++ b/src/tests/test_send_to_statsd.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import unicode_literals
+
+import six
+
+
+from src.send_to_statsd import send_timed_step_elapsed_time_in_seconds_to_statsd
+from src.step_timer import manage_step_timer, retrieve_time_step_object_from_pickled_file, TimedStep
+
+if six.PY3:
+    from unittest.mock import Mock
+else:
+    from mock import Mock
+
+
+class TestSendToStatsd(object):
+    def setup_class(self):
+        self.metric_name = 'step_elapsed_time_seconds'
+        self.metric_description = 'Elapsed time until a step has been finished'
+        self.labels = 'step_name'
+
+    def test_can_send_a_timed_step_object_to_statsd_server(self):
+        resource_name = 'statsd.timer'
+        manage_step_timer(step_name='PROM STEP', moment='start', resource=resource_name)
+        manage_step_timer(step_name='PROM STEP', moment='end', resource=resource_name)
+        timed_step = retrieve_time_step_object_from_pickled_file(resource=resource_name)
+        author = 'gcavalcante8808'
+        metric_type = 'unittests'
+        statsd_metric_name = '{}.{}.{}.{}'.format(self.metric_name, author, metric_type, timed_step.step_name)
+
+
+        metric_name, metric_value = send_timed_step_elapsed_time_in_seconds_to_statsd(
+            resource=resource_name,
+            gateway=Mock(),
+            statsd_metric_name=statsd_metric_name)
+
+        assert metric_name == statsd_metric_name
+        assert metric_value == timed_step.elapsed_time_in_seconds


### PR DESCRIPTION
## Scenario

Sometimes prometheus gateway is too harsh to promote related metrics (tests: type1, type2, type3) and statsd isn`t.

## What Has been Done

- [x] Added send_to_statsd cli script.
- [x] Bump Release into 1.1.